### PR TITLE
Remove PHPStan default from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
 		"lint:md:docs": "npm run lint:md:docs",
 		"lint:php": "phpcs -v --standard=phpcs.xml.dist",
 		"lint:phpmd": "phpmd . text phpmd.xml.dist",
-		"lint:phpstan": "phpstan analyse -c phpstan.neon --memory-limit=1G",
+		"lint:phpstan": "phpstan analyse --memory-limit=1G",
 		"lint:pkg-json": "npm run lint:pkg-json",
 		"phpcs-i": "phpcs -i",
 		"scripts-list": "composer run-script --list",


### PR DESCRIPTION
@pedro-mendonca PHPStan automatically loads phpstan.neon
