### PR TITLE
Add support for WP 6.5 Performant Translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Go to "Translations" on the Updates screen and choose what you want to update.
 * .po (editable translation files)
 * .mo (binary translation files)
 * .json (JavaScript translation files)
+* .l10n.php (PHP performant translation files)
 
 ### WordPress Translations tests and info in Site Health
 
@@ -152,6 +153,7 @@ Sure! You are welcome to report any issues or add feature suggestions on the [Gi
 ### Unreleased
 
 * Tested up to WP 6.5
+* Generate .l10n.php performant translation files for WordPress 6.5
 
 ### 1.6.0
 

--- a/includes/class-update-translations.php
+++ b/includes/class-update-translations.php
@@ -11,6 +11,7 @@ namespace Translation_Tools;
 
 use Gettext\Translations;
 use WP_Error;
+use WP_Translation_File;
 
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -125,6 +126,16 @@ if ( ! class_exists( __NAMESPACE__ . '\Update_Translations' ) ) {
 				$result['data'] = $generate_mo['data'];
 				if ( is_wp_error( $result['data'] ) ) {
 					return $result;
+				}
+
+				// Generate .l10n.php from .mo file on WordPress 6.5.
+				if ( class_exists( 'WP_Translation_File' ) && ! is_wp_error( $generate_mo ) ) {
+					$generate_php = $this->generate_php( $destination, $project, $locale );
+					array_push( $result['log'], $generate_php['log'] );
+					$result['data'] = $generate_php['data'];
+					if ( is_wp_error( $result['data'] ) ) {
+						return $result;
+					}
 				}
 			}
 
@@ -429,6 +440,71 @@ if ( ! class_exists( __NAMESPACE__ . '\Update_Translations' ) ) {
 				// Report message.
 				$result['data'] = new WP_Error(
 					'generate-mo',
+					esc_html__( 'Could not create file.', 'translation-tools' )
+				);
+				return $result;
+
+			}
+
+			$result['data'] = true;
+
+			return $result;
+		}
+
+
+		/**
+		 * Generate .l10n.php file from .mo file.
+		 *
+		 * @since 1.6.1
+		 *
+		 * @param string $destination   Local destination of the language file. ( e.g: local/site/wp-content/languages/ ).
+		 * @param array  $project       Project array.
+		 * @param Locale $locale        Locale object.
+		 *
+		 * @return array|WP_Error       Array on success, WP_Error on failure.
+		 */
+		public function generate_php( $destination, $project, $locale ) {
+
+			// Set the file naming convention. ( e.g.: {domain}-{locale}.po ).
+			$domain        = $project['Domain'] ? $project['Domain'] . '-' : '';
+			$mo_file_name  = $domain . $locale->wp_locale . '.mo';
+			$php_file_name = $domain . $locale->wp_locale . '.l10n.php';
+
+			// Define variable.
+			$result = array();
+
+			// Check if .po file exist.
+			if ( ! is_file( $destination . $mo_file_name ) ) {
+
+				// Report message.
+				$result['data'] = new WP_Error(
+					'extract-mo',
+					esc_html__( 'File not found.', 'translation-tools' )
+				);
+
+				return $result;
+			}
+
+			// Report message.
+			$result['log'] = sprintf(
+				/* translators: %s: File name. */
+				esc_html__( 'Saving file %s…', 'translation-tools' ),
+				'<code>' . $php_file_name . '</code>'
+			);
+
+			// Generate .l10n.php file.
+			$generate = false;
+
+			$contents = WP_Translation_File::transform( $destination . $mo_file_name, 'php' );
+			if ( $contents ) {
+				$generate = file_put_contents( $destination . $php_file_name, $contents );
+			}
+
+			if ( ! $generate ) {
+
+				// Report message.
+				$result['data'] = new WP_Error(
+					'generate-php',
 					esc_html__( 'Could not create file.', 'translation-tools' )
 				);
 				return $result;

--- a/includes/class-update-translations.php
+++ b/includes/class-update-translations.php
@@ -130,8 +130,8 @@ if ( ! class_exists( __NAMESPACE__ . '\Update_Translations' ) ) {
 
 				// Generate .l10n.php from .mo file on WordPress 6.5.
 				if ( class_exists( 'WP_Translation_File' ) && ! is_wp_error( $generate_mo ) ) {
-					$generate_php = $this->generate_php( $destination, $project, $locale );
-					array_push( $result['log'], $generate_php['log'] );
+					$generate_php   = $this->generate_php( $destination, $project, $locale );
+					$result['log']  = array_merge( $result['log'], $generate_php['log'] );
 					$result['data'] = $generate_php['data'];
 					if ( is_wp_error( $result['data'] ) ) {
 						return $result;
@@ -309,6 +309,8 @@ if ( ! class_exists( __NAMESPACE__ . '\Update_Translations' ) ) {
 		 */
 		public function generate_po( $destination, $project, $locale, $response ) {
 
+			global $wp_filesystem;
+
 			// Set the file naming convention. ( e.g.: {domain}-{locale}.po ).
 			$domain    = $project['Domain'] ? $project['Domain'] . '-' : '';
 			$file_name = $domain . $locale->wp_locale . '.po';
@@ -324,9 +326,9 @@ if ( ! class_exists( __NAMESPACE__ . '\Update_Translations' ) ) {
 			);
 
 			// Generate .po file.
-			$success = file_put_contents( $destination . $file_name, $response['body'] ); // phpcs:ignore
+			$generate = $wp_filesystem->put_contents( $destination . $file_name, $response['body'], FS_CHMOD_FILE );
 
-			if ( ! $success ) {
+			if ( ! $generate ) {
 
 				// Report message.
 				$result['data'] = new WP_Error(
@@ -455,7 +457,7 @@ if ( ! class_exists( __NAMESPACE__ . '\Update_Translations' ) ) {
 		/**
 		 * Generate .l10n.php file from .mo file.
 		 *
-		 * @since 1.6.1
+		 * @since 1.7.0
 		 *
 		 * @param string $destination   Local destination of the language file. ( e.g: local/site/wp-content/languages/ ).
 		 * @param array  $project       Project array.
@@ -465,7 +467,9 @@ if ( ! class_exists( __NAMESPACE__ . '\Update_Translations' ) ) {
 		 */
 		public function generate_php( $destination, $project, $locale ) {
 
-			// Set the file naming convention. ( e.g.: {domain}-{locale}.po ).
+			global $wp_filesystem;
+
+			// Set the file naming convention. ( e.g.: {domain}-{locale}.mo ).
 			$domain        = $project['Domain'] ? $project['Domain'] . '-' : '';
 			$mo_file_name  = $domain . $locale->wp_locale . '.mo';
 			$php_file_name = $domain . $locale->wp_locale . '.l10n.php';
@@ -473,7 +477,7 @@ if ( ! class_exists( __NAMESPACE__ . '\Update_Translations' ) ) {
 			// Define variable.
 			$result = array();
 
-			// Check if .po file exist.
+			// Check if .mo file exist.
 			if ( ! is_file( $destination . $mo_file_name ) ) {
 
 				// Report message.
@@ -486,19 +490,35 @@ if ( ! class_exists( __NAMESPACE__ . '\Update_Translations' ) ) {
 			}
 
 			// Report message.
-			$result['log'] = sprintf(
+			$result['log'][] = sprintf(
+				/* translators: %s: File name. */
+				esc_html__( 'Extracting translations from file %s…', 'translation-tools' ),
+				'<code>' . esc_html( $mo_file_name ) . '</code>'
+			);
+
+			// Get translation content from .mo file.
+			$contents = WP_Translation_File::transform( $destination . $mo_file_name, 'php' ); // @phpstan-ignore-line until the WP 6.5 Stubs are released.
+
+			if ( ! $contents ) {
+
+				// Report message.
+				$result['data'] = new WP_Error(
+					'transform-mo-php',
+					esc_html__( 'Could not extract translations from file.', 'translation-tools' )
+				);
+				return $result;
+
+			}
+
+			// Report message.
+			$result['log'][] = sprintf(
 				/* translators: %s: File name. */
 				esc_html__( 'Saving file %s…', 'translation-tools' ),
 				'<code>' . $php_file_name . '</code>'
 			);
 
 			// Generate .l10n.php file.
-			$generate = false;
-
-			$contents = WP_Translation_File::transform( $destination . $mo_file_name, 'php' );
-			if ( $contents ) {
-				$generate = file_put_contents( $destination . $php_file_name, $contents );
-			}
+			$generate = $wp_filesystem->put_contents( $destination . $php_file_name, $contents, FS_CHMOD_FILE );
 
 			if ( ! $generate ) {
 

--- a/readme.txt
+++ b/readme.txt
@@ -115,7 +115,7 @@ Sure! You are welcome to report any issues or add feature suggestions on the [Gi
 
 = Unreleased =
 *   Tested up to WP 6.5
-*   Generate .l10n.php for WordPress 6.5
+*   Generate .l10n.php performant translation files for WordPress 6.5
 
 = 1.6.0 =
 *   Tested up to WP 6.2

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,7 @@ Go to "Translations" on the Updates screen and choose what you want to update.
 *   .po (editable translation files)
 *   .mo (binary translation files)
 *   .json (JavaScript translation files)
+*   .l10n.php (PHP performant translation files)
 
 ### WordPress Translations tests and info in Site Health ###
 
@@ -114,6 +115,7 @@ Sure! You are welcome to report any issues or add feature suggestions on the [Gi
 
 = Unreleased =
 *   Tested up to WP 6.5
+*   Generate .l10n.php for WordPress 6.5
 
 = 1.6.0 =
 *   Tested up to WP 6.2


### PR DESCRIPTION
## Description
- [x] Check for WordPress 6.5 class `WP_Translation_File`
- [x] Extract `.mo` file contents
- [x] Save `.l10n.php` file

Documentation
https://make.wordpress.org/core/2024/02/27/i18n-improvements-6-5-performant-translations/